### PR TITLE
support search by unix time

### DIFF
--- a/generator.go
+++ b/generator.go
@@ -318,15 +318,7 @@ func (st *BuildStruct) emit(g *genbase.Generator) error {
 		} else if field.Tag.UnixTime {
 			if field.fieldInfo.IsTime() {
 				g.Printf(`
-						// Number Field is value between -2,147,483,647 and 2,147,483,647.
-						// https://cloud.google.com/appengine/docs/go/search/#Go_Documents_and_fields
-						unixtime := src.%[1]s.Unix()
-						if unixtime < -2147483647 {
-							unixtime = -2147483647
-						} else if 2147483647 < unixtime {
-							unixtime = 2147483647
-						}
-						dest.%[1]sUnixTime = float64(unixtime)
+						dest.%[1]sUnixTime = float64(smgutils.Unix(src.%[1]s))
 						dest.%[1]s = src.%[1]s
 					`, field.Name)
 			} else {
@@ -865,36 +857,98 @@ func (st *BuildStruct) emit(g *genbase.Generator) error {
 
 			// GreaterThanOrEqual add query operand.
 			func (p *%[1]sSearchUnixTimePropertyInfo) GreaterThanOrEqual(value time.Time) *%[1]sSearchBuilder {
-				p.b.currentOp.Children = append(p.b.currentOp.Children, &smgutils.Op{FieldName: p.Name + "UnixTime", Type: smgutils.GtEq, Value: value.Unix()})
+				p.b.currentOp.Children = append(p.b.currentOp.Children, &smgutils.Op{FieldName: p.Name, Type: smgutils.GtEq, Value: value.UTC()})
 				return p.b
 			}
 
 			// GreaterThan add query operand.
 			func (p *%[1]sSearchUnixTimePropertyInfo) GreaterThan(value time.Time) *%[1]sSearchBuilder {
-				p.b.currentOp.Children = append(p.b.currentOp.Children, &smgutils.Op{FieldName: p.Name + "UnixTime", Type: smgutils.Gt, Value: value.Unix()})
+				p.b.currentOp.Children = append(p.b.currentOp.Children, &smgutils.Op{FieldName: p.Name, Type: smgutils.Gt, Value: value.UTC()})
 				return p.b
 			}
 
 			// LessThanOrEqual add query operand.
 			func (p *%[1]sSearchUnixTimePropertyInfo) LessThanOrEqual(value time.Time) *%[1]sSearchBuilder {
-				p.b.currentOp.Children = append(p.b.currentOp.Children, &smgutils.Op{FieldName: p.Name + "UnixTime", Type: smgutils.LtEq, Value: value.Unix()})
+				p.b.currentOp.Children = append(p.b.currentOp.Children, &smgutils.Op{FieldName: p.Name, Type: smgutils.LtEq, Value: value.UTC()})
 				return p.b
 			}
 
 			// LessThan add query operand.
 			func (p *%[1]sSearchUnixTimePropertyInfo) LessThan(value time.Time) *%[1]sSearchBuilder {
-				p.b.currentOp.Children = append(p.b.currentOp.Children, &smgutils.Op{FieldName: p.Name + "UnixTime", Type: smgutils.Lt, Value: value.Unix()})
+				p.b.currentOp.Children = append(p.b.currentOp.Children, &smgutils.Op{FieldName: p.Name, Type: smgutils.Lt, Value: value.UTC()})
 				return p.b
 			}
 
 			// Equal add query operand.
 			func (p *%[1]sSearchUnixTimePropertyInfo) Equal(value time.Time) *%[1]sSearchBuilder {
-				p.b.currentOp.Children = append(p.b.currentOp.Children, &smgutils.Op{FieldName: p.Name + "UnixTime", Type: smgutils.Eq, Value: value.Unix()})
+				p.b.currentOp.Children = append(p.b.currentOp.Children, &smgutils.Op{FieldName: p.Name, Type: smgutils.Eq, Value: value.UTC()})
 				return p.b
 			}
 
 			// Asc add query operand.
 			func (p *%[1]sSearchUnixTimePropertyInfo) Asc() *%[1]sSearchBuilder {
+				if p.b.opts == nil {
+					p.b.opts = &search.SearchOptions{}
+				}
+				if p.b.opts.Sort == nil {
+					p.b.opts.Sort = &search.SortOptions{}
+				}
+				p.b.opts.Sort.Expressions = append(p.b.opts.Sort.Expressions, search.SortExpression{
+					Expr:    p.Name,
+					Reverse: true,
+				})
+
+				return p.b
+			}
+
+			// Desc add query operand.
+			func (p *%[1]sSearchUnixTimePropertyInfo) Desc() *%[1]sSearchBuilder {
+				if p.b.opts == nil {
+					p.b.opts = &search.SearchOptions{}
+				}
+				if p.b.opts.Sort == nil {
+					p.b.opts.Sort = &search.SortOptions{}
+				}
+				p.b.opts.Sort.Expressions = append(p.b.opts.Sort.Expressions, search.SortExpression{
+					Expr:    p.Name,
+					Reverse: false,
+				})
+
+				return p.b
+			}
+
+			// UnixTimeGreaterThanOrEqual add query operand.
+			func (p *%[1]sSearchUnixTimePropertyInfo) UnixTimeGreaterThanOrEqual(value time.Time) *%[1]sSearchBuilder {
+				p.b.currentOp.Children = append(p.b.currentOp.Children, &smgutils.Op{FieldName: p.Name + "UnixTime", Type: smgutils.GtEq, Value: smgutils.Unix(value)})
+				return p.b
+			}
+
+			// UnixTimeGreaterThan add query operand.
+			func (p *%[1]sSearchUnixTimePropertyInfo) UnixTimeGreaterThan(value time.Time) *%[1]sSearchBuilder {
+				p.b.currentOp.Children = append(p.b.currentOp.Children, &smgutils.Op{FieldName: p.Name + "UnixTime", Type: smgutils.Gt, Value: smgutils.Unix(value)})
+				return p.b
+			}
+
+			// UnixTimeLessThanOrEqual add query operand.
+			func (p *%[1]sSearchUnixTimePropertyInfo) UnixTimeLessThanOrEqual(value time.Time) *%[1]sSearchBuilder {
+				p.b.currentOp.Children = append(p.b.currentOp.Children, &smgutils.Op{FieldName: p.Name + "UnixTime", Type: smgutils.LtEq, Value: smgutils.Unix(value)})
+				return p.b
+			}
+
+			// UnixTimeLessThan add query operand.
+			func (p *%[1]sSearchUnixTimePropertyInfo) UnixTimeLessThan(value time.Time) *%[1]sSearchBuilder {
+				p.b.currentOp.Children = append(p.b.currentOp.Children, &smgutils.Op{FieldName: p.Name + "UnixTime", Type: smgutils.Lt, Value: smgutils.Unix(value)})
+				return p.b
+			}
+
+			// UnixTimeEqual add query operand.
+			func (p *%[1]sSearchUnixTimePropertyInfo) UnixTimeEqual(value time.Time) *%[1]sSearchBuilder {
+				p.b.currentOp.Children = append(p.b.currentOp.Children, &smgutils.Op{FieldName: p.Name + "UnixTime", Type: smgutils.Eq, Value: smgutils.Unix(value)})
+				return p.b
+			}
+
+			// UnixTimeAsc add query operand.
+			func (p *%[1]sSearchUnixTimePropertyInfo) UnixTimeAsc() *%[1]sSearchBuilder {
 				if p.b.opts == nil {
 					p.b.opts = &search.SearchOptions{}
 				}
@@ -909,8 +963,8 @@ func (st *BuildStruct) emit(g *genbase.Generator) error {
 				return p.b
 			}
 
-			// Desc add query operand.
-			func (p *%[1]sSearchUnixTimePropertyInfo) Desc() *%[1]sSearchBuilder {
+			// UnixTimeDesc add query operand.
+			func (p *%[1]sSearchUnixTimePropertyInfo) UnixTimeDesc() *%[1]sSearchBuilder {
 				if p.b.opts == nil {
 					p.b.opts = &search.SearchOptions{}
 				}

--- a/generator.go
+++ b/generator.go
@@ -319,12 +319,14 @@ func (st *BuildStruct) emit(g *genbase.Generator) error {
 			if field.fieldInfo.IsTime() {
 				g.Printf(`
 						// Number Field is value between -2,147,483,647 and 2,147,483,647.
-						// but, value of zero time is -62,135,596,800.
-						if src.%[1]s.IsZero() {
-							dest.%[1]sUnixTime = float64(-1)
-						} else {
-							dest.%[1]sUnixTime = float64(src.%[1]s.Unix())
+						// https://cloud.google.com/appengine/docs/go/search/#Go_Documents_and_fields
+						unixtime := src.%[1]s.Unix()
+						if unixtime < -2147483647 {
+							unixtime = -2147483647
+						} else if 2147483647 < unixtime {
+							unixtime = 2147483647
 						}
+						dest.%[1]sUnixTime = float64(unixtime)
 						dest.%[1]s = src.%[1]s
 					`, field.Name)
 			} else {

--- a/misc/fixture/a/model_search.go
+++ b/misc/fixture/a/model_search.go
@@ -484,36 +484,98 @@ type SampleSearchUnixTimePropertyInfo struct {
 
 // GreaterThanOrEqual add query operand.
 func (p *SampleSearchUnixTimePropertyInfo) GreaterThanOrEqual(value time.Time) *SampleSearchBuilder {
-	p.b.currentOp.Children = append(p.b.currentOp.Children, &smgutils.Op{FieldName: p.Name + "UnixTime", Type: smgutils.GtEq, Value: value.Unix()})
+	p.b.currentOp.Children = append(p.b.currentOp.Children, &smgutils.Op{FieldName: p.Name, Type: smgutils.GtEq, Value: value.UTC()})
 	return p.b
 }
 
 // GreaterThan add query operand.
 func (p *SampleSearchUnixTimePropertyInfo) GreaterThan(value time.Time) *SampleSearchBuilder {
-	p.b.currentOp.Children = append(p.b.currentOp.Children, &smgutils.Op{FieldName: p.Name + "UnixTime", Type: smgutils.Gt, Value: value.Unix()})
+	p.b.currentOp.Children = append(p.b.currentOp.Children, &smgutils.Op{FieldName: p.Name, Type: smgutils.Gt, Value: value.UTC()})
 	return p.b
 }
 
 // LessThanOrEqual add query operand.
 func (p *SampleSearchUnixTimePropertyInfo) LessThanOrEqual(value time.Time) *SampleSearchBuilder {
-	p.b.currentOp.Children = append(p.b.currentOp.Children, &smgutils.Op{FieldName: p.Name + "UnixTime", Type: smgutils.LtEq, Value: value.Unix()})
+	p.b.currentOp.Children = append(p.b.currentOp.Children, &smgutils.Op{FieldName: p.Name, Type: smgutils.LtEq, Value: value.UTC()})
 	return p.b
 }
 
 // LessThan add query operand.
 func (p *SampleSearchUnixTimePropertyInfo) LessThan(value time.Time) *SampleSearchBuilder {
-	p.b.currentOp.Children = append(p.b.currentOp.Children, &smgutils.Op{FieldName: p.Name + "UnixTime", Type: smgutils.Lt, Value: value.Unix()})
+	p.b.currentOp.Children = append(p.b.currentOp.Children, &smgutils.Op{FieldName: p.Name, Type: smgutils.Lt, Value: value.UTC()})
 	return p.b
 }
 
 // Equal add query operand.
 func (p *SampleSearchUnixTimePropertyInfo) Equal(value time.Time) *SampleSearchBuilder {
-	p.b.currentOp.Children = append(p.b.currentOp.Children, &smgutils.Op{FieldName: p.Name + "UnixTime", Type: smgutils.Eq, Value: value.Unix()})
+	p.b.currentOp.Children = append(p.b.currentOp.Children, &smgutils.Op{FieldName: p.Name, Type: smgutils.Eq, Value: value.UTC()})
 	return p.b
 }
 
 // Asc add query operand.
 func (p *SampleSearchUnixTimePropertyInfo) Asc() *SampleSearchBuilder {
+	if p.b.opts == nil {
+		p.b.opts = &search.SearchOptions{}
+	}
+	if p.b.opts.Sort == nil {
+		p.b.opts.Sort = &search.SortOptions{}
+	}
+	p.b.opts.Sort.Expressions = append(p.b.opts.Sort.Expressions, search.SortExpression{
+		Expr:    p.Name,
+		Reverse: true,
+	})
+
+	return p.b
+}
+
+// Desc add query operand.
+func (p *SampleSearchUnixTimePropertyInfo) Desc() *SampleSearchBuilder {
+	if p.b.opts == nil {
+		p.b.opts = &search.SearchOptions{}
+	}
+	if p.b.opts.Sort == nil {
+		p.b.opts.Sort = &search.SortOptions{}
+	}
+	p.b.opts.Sort.Expressions = append(p.b.opts.Sort.Expressions, search.SortExpression{
+		Expr:    p.Name,
+		Reverse: false,
+	})
+
+	return p.b
+}
+
+// UnixTimeGreaterThanOrEqual add query operand.
+func (p *SampleSearchUnixTimePropertyInfo) UnixTimeGreaterThanOrEqual(value time.Time) *SampleSearchBuilder {
+	p.b.currentOp.Children = append(p.b.currentOp.Children, &smgutils.Op{FieldName: p.Name + "UnixTime", Type: smgutils.GtEq, Value: smgutils.Unix(value)})
+	return p.b
+}
+
+// UnixTimeGreaterThan add query operand.
+func (p *SampleSearchUnixTimePropertyInfo) UnixTimeGreaterThan(value time.Time) *SampleSearchBuilder {
+	p.b.currentOp.Children = append(p.b.currentOp.Children, &smgutils.Op{FieldName: p.Name + "UnixTime", Type: smgutils.Gt, Value: smgutils.Unix(value)})
+	return p.b
+}
+
+// UnixTimeLessThanOrEqual add query operand.
+func (p *SampleSearchUnixTimePropertyInfo) UnixTimeLessThanOrEqual(value time.Time) *SampleSearchBuilder {
+	p.b.currentOp.Children = append(p.b.currentOp.Children, &smgutils.Op{FieldName: p.Name + "UnixTime", Type: smgutils.LtEq, Value: smgutils.Unix(value)})
+	return p.b
+}
+
+// UnixTimeLessThan add query operand.
+func (p *SampleSearchUnixTimePropertyInfo) UnixTimeLessThan(value time.Time) *SampleSearchBuilder {
+	p.b.currentOp.Children = append(p.b.currentOp.Children, &smgutils.Op{FieldName: p.Name + "UnixTime", Type: smgutils.Lt, Value: smgutils.Unix(value)})
+	return p.b
+}
+
+// UnixTimeEqual add query operand.
+func (p *SampleSearchUnixTimePropertyInfo) UnixTimeEqual(value time.Time) *SampleSearchBuilder {
+	p.b.currentOp.Children = append(p.b.currentOp.Children, &smgutils.Op{FieldName: p.Name + "UnixTime", Type: smgutils.Eq, Value: smgutils.Unix(value)})
+	return p.b
+}
+
+// UnixTimeAsc add query operand.
+func (p *SampleSearchUnixTimePropertyInfo) UnixTimeAsc() *SampleSearchBuilder {
 	if p.b.opts == nil {
 		p.b.opts = &search.SearchOptions{}
 	}
@@ -528,8 +590,8 @@ func (p *SampleSearchUnixTimePropertyInfo) Asc() *SampleSearchBuilder {
 	return p.b
 }
 
-// Desc add query operand.
-func (p *SampleSearchUnixTimePropertyInfo) Desc() *SampleSearchBuilder {
+// UnixTimeDesc add query operand.
+func (p *SampleSearchUnixTimePropertyInfo) UnixTimeDesc() *SampleSearchBuilder {
 	if p.b.opts == nil {
 		p.b.opts = &search.SearchOptions{}
 	}

--- a/misc/fixture/a/model_search.go
+++ b/misc/fixture/a/model_search.go
@@ -475,3 +475,71 @@ func (p *SampleSearchTimePropertyInfo) Desc() *SampleSearchBuilder {
 
 	return p.b
 }
+
+// SampleSearchUnixTimePropertyInfo hold property info.
+type SampleSearchUnixTimePropertyInfo struct {
+	Name string
+	b    *SampleSearchBuilder
+}
+
+// GreaterThanOrEqual add query operand.
+func (p *SampleSearchUnixTimePropertyInfo) GreaterThanOrEqual(value time.Time) *SampleSearchBuilder {
+	p.b.currentOp.Children = append(p.b.currentOp.Children, &smgutils.Op{FieldName: p.Name + "UnixTime", Type: smgutils.GtEq, Value: value.Unix()})
+	return p.b
+}
+
+// GreaterThan add query operand.
+func (p *SampleSearchUnixTimePropertyInfo) GreaterThan(value time.Time) *SampleSearchBuilder {
+	p.b.currentOp.Children = append(p.b.currentOp.Children, &smgutils.Op{FieldName: p.Name + "UnixTime", Type: smgutils.Gt, Value: value.Unix()})
+	return p.b
+}
+
+// LessThanOrEqual add query operand.
+func (p *SampleSearchUnixTimePropertyInfo) LessThanOrEqual(value time.Time) *SampleSearchBuilder {
+	p.b.currentOp.Children = append(p.b.currentOp.Children, &smgutils.Op{FieldName: p.Name + "UnixTime", Type: smgutils.LtEq, Value: value.Unix()})
+	return p.b
+}
+
+// LessThan add query operand.
+func (p *SampleSearchUnixTimePropertyInfo) LessThan(value time.Time) *SampleSearchBuilder {
+	p.b.currentOp.Children = append(p.b.currentOp.Children, &smgutils.Op{FieldName: p.Name + "UnixTime", Type: smgutils.Lt, Value: value.Unix()})
+	return p.b
+}
+
+// Equal add query operand.
+func (p *SampleSearchUnixTimePropertyInfo) Equal(value time.Time) *SampleSearchBuilder {
+	p.b.currentOp.Children = append(p.b.currentOp.Children, &smgutils.Op{FieldName: p.Name + "UnixTime", Type: smgutils.Eq, Value: value.Unix()})
+	return p.b
+}
+
+// Asc add query operand.
+func (p *SampleSearchUnixTimePropertyInfo) Asc() *SampleSearchBuilder {
+	if p.b.opts == nil {
+		p.b.opts = &search.SearchOptions{}
+	}
+	if p.b.opts.Sort == nil {
+		p.b.opts.Sort = &search.SortOptions{}
+	}
+	p.b.opts.Sort.Expressions = append(p.b.opts.Sort.Expressions, search.SortExpression{
+		Expr:    p.Name + "UnixTime",
+		Reverse: true,
+	})
+
+	return p.b
+}
+
+// Desc add query operand.
+func (p *SampleSearchUnixTimePropertyInfo) Desc() *SampleSearchBuilder {
+	if p.b.opts == nil {
+		p.b.opts = &search.SearchOptions{}
+	}
+	if p.b.opts.Sort == nil {
+		p.b.opts.Sort = &search.SortOptions{}
+	}
+	p.b.opts.Sort.Expressions = append(p.b.opts.Sort.Expressions, search.SortExpression{
+		Expr:    p.Name + "UnixTime",
+		Reverse: false,
+	})
+
+	return p.b
+}

--- a/misc/fixture/b/model_search.go
+++ b/misc/fixture/b/model_search.go
@@ -512,36 +512,98 @@ type SampleSearchUnixTimePropertyInfo struct {
 
 // GreaterThanOrEqual add query operand.
 func (p *SampleSearchUnixTimePropertyInfo) GreaterThanOrEqual(value time.Time) *SampleSearchBuilder {
-	p.b.currentOp.Children = append(p.b.currentOp.Children, &smgutils.Op{FieldName: p.Name + "UnixTime", Type: smgutils.GtEq, Value: value.Unix()})
+	p.b.currentOp.Children = append(p.b.currentOp.Children, &smgutils.Op{FieldName: p.Name, Type: smgutils.GtEq, Value: value.UTC()})
 	return p.b
 }
 
 // GreaterThan add query operand.
 func (p *SampleSearchUnixTimePropertyInfo) GreaterThan(value time.Time) *SampleSearchBuilder {
-	p.b.currentOp.Children = append(p.b.currentOp.Children, &smgutils.Op{FieldName: p.Name + "UnixTime", Type: smgutils.Gt, Value: value.Unix()})
+	p.b.currentOp.Children = append(p.b.currentOp.Children, &smgutils.Op{FieldName: p.Name, Type: smgutils.Gt, Value: value.UTC()})
 	return p.b
 }
 
 // LessThanOrEqual add query operand.
 func (p *SampleSearchUnixTimePropertyInfo) LessThanOrEqual(value time.Time) *SampleSearchBuilder {
-	p.b.currentOp.Children = append(p.b.currentOp.Children, &smgutils.Op{FieldName: p.Name + "UnixTime", Type: smgutils.LtEq, Value: value.Unix()})
+	p.b.currentOp.Children = append(p.b.currentOp.Children, &smgutils.Op{FieldName: p.Name, Type: smgutils.LtEq, Value: value.UTC()})
 	return p.b
 }
 
 // LessThan add query operand.
 func (p *SampleSearchUnixTimePropertyInfo) LessThan(value time.Time) *SampleSearchBuilder {
-	p.b.currentOp.Children = append(p.b.currentOp.Children, &smgutils.Op{FieldName: p.Name + "UnixTime", Type: smgutils.Lt, Value: value.Unix()})
+	p.b.currentOp.Children = append(p.b.currentOp.Children, &smgutils.Op{FieldName: p.Name, Type: smgutils.Lt, Value: value.UTC()})
 	return p.b
 }
 
 // Equal add query operand.
 func (p *SampleSearchUnixTimePropertyInfo) Equal(value time.Time) *SampleSearchBuilder {
-	p.b.currentOp.Children = append(p.b.currentOp.Children, &smgutils.Op{FieldName: p.Name + "UnixTime", Type: smgutils.Eq, Value: value.Unix()})
+	p.b.currentOp.Children = append(p.b.currentOp.Children, &smgutils.Op{FieldName: p.Name, Type: smgutils.Eq, Value: value.UTC()})
 	return p.b
 }
 
 // Asc add query operand.
 func (p *SampleSearchUnixTimePropertyInfo) Asc() *SampleSearchBuilder {
+	if p.b.opts == nil {
+		p.b.opts = &search.SearchOptions{}
+	}
+	if p.b.opts.Sort == nil {
+		p.b.opts.Sort = &search.SortOptions{}
+	}
+	p.b.opts.Sort.Expressions = append(p.b.opts.Sort.Expressions, search.SortExpression{
+		Expr:    p.Name,
+		Reverse: true,
+	})
+
+	return p.b
+}
+
+// Desc add query operand.
+func (p *SampleSearchUnixTimePropertyInfo) Desc() *SampleSearchBuilder {
+	if p.b.opts == nil {
+		p.b.opts = &search.SearchOptions{}
+	}
+	if p.b.opts.Sort == nil {
+		p.b.opts.Sort = &search.SortOptions{}
+	}
+	p.b.opts.Sort.Expressions = append(p.b.opts.Sort.Expressions, search.SortExpression{
+		Expr:    p.Name,
+		Reverse: false,
+	})
+
+	return p.b
+}
+
+// UnixTimeGreaterThanOrEqual add query operand.
+func (p *SampleSearchUnixTimePropertyInfo) UnixTimeGreaterThanOrEqual(value time.Time) *SampleSearchBuilder {
+	p.b.currentOp.Children = append(p.b.currentOp.Children, &smgutils.Op{FieldName: p.Name + "UnixTime", Type: smgutils.GtEq, Value: smgutils.Unix(value)})
+	return p.b
+}
+
+// UnixTimeGreaterThan add query operand.
+func (p *SampleSearchUnixTimePropertyInfo) UnixTimeGreaterThan(value time.Time) *SampleSearchBuilder {
+	p.b.currentOp.Children = append(p.b.currentOp.Children, &smgutils.Op{FieldName: p.Name + "UnixTime", Type: smgutils.Gt, Value: smgutils.Unix(value)})
+	return p.b
+}
+
+// UnixTimeLessThanOrEqual add query operand.
+func (p *SampleSearchUnixTimePropertyInfo) UnixTimeLessThanOrEqual(value time.Time) *SampleSearchBuilder {
+	p.b.currentOp.Children = append(p.b.currentOp.Children, &smgutils.Op{FieldName: p.Name + "UnixTime", Type: smgutils.LtEq, Value: smgutils.Unix(value)})
+	return p.b
+}
+
+// UnixTimeLessThan add query operand.
+func (p *SampleSearchUnixTimePropertyInfo) UnixTimeLessThan(value time.Time) *SampleSearchBuilder {
+	p.b.currentOp.Children = append(p.b.currentOp.Children, &smgutils.Op{FieldName: p.Name + "UnixTime", Type: smgutils.Lt, Value: smgutils.Unix(value)})
+	return p.b
+}
+
+// UnixTimeEqual add query operand.
+func (p *SampleSearchUnixTimePropertyInfo) UnixTimeEqual(value time.Time) *SampleSearchBuilder {
+	p.b.currentOp.Children = append(p.b.currentOp.Children, &smgutils.Op{FieldName: p.Name + "UnixTime", Type: smgutils.Eq, Value: smgutils.Unix(value)})
+	return p.b
+}
+
+// UnixTimeAsc add query operand.
+func (p *SampleSearchUnixTimePropertyInfo) UnixTimeAsc() *SampleSearchBuilder {
 	if p.b.opts == nil {
 		p.b.opts = &search.SearchOptions{}
 	}
@@ -556,8 +618,8 @@ func (p *SampleSearchUnixTimePropertyInfo) Asc() *SampleSearchBuilder {
 	return p.b
 }
 
-// Desc add query operand.
-func (p *SampleSearchUnixTimePropertyInfo) Desc() *SampleSearchBuilder {
+// UnixTimeDesc add query operand.
+func (p *SampleSearchUnixTimePropertyInfo) UnixTimeDesc() *SampleSearchBuilder {
 	if p.b.opts == nil {
 		p.b.opts = &search.SearchOptions{}
 	}

--- a/misc/fixture/b/model_search.go
+++ b/misc/fixture/b/model_search.go
@@ -503,3 +503,71 @@ func (p *SampleSearchTimePropertyInfo) Desc() *SampleSearchBuilder {
 
 	return p.b
 }
+
+// SampleSearchUnixTimePropertyInfo hold property info.
+type SampleSearchUnixTimePropertyInfo struct {
+	Name string
+	b    *SampleSearchBuilder
+}
+
+// GreaterThanOrEqual add query operand.
+func (p *SampleSearchUnixTimePropertyInfo) GreaterThanOrEqual(value time.Time) *SampleSearchBuilder {
+	p.b.currentOp.Children = append(p.b.currentOp.Children, &smgutils.Op{FieldName: p.Name + "UnixTime", Type: smgutils.GtEq, Value: value.Unix()})
+	return p.b
+}
+
+// GreaterThan add query operand.
+func (p *SampleSearchUnixTimePropertyInfo) GreaterThan(value time.Time) *SampleSearchBuilder {
+	p.b.currentOp.Children = append(p.b.currentOp.Children, &smgutils.Op{FieldName: p.Name + "UnixTime", Type: smgutils.Gt, Value: value.Unix()})
+	return p.b
+}
+
+// LessThanOrEqual add query operand.
+func (p *SampleSearchUnixTimePropertyInfo) LessThanOrEqual(value time.Time) *SampleSearchBuilder {
+	p.b.currentOp.Children = append(p.b.currentOp.Children, &smgutils.Op{FieldName: p.Name + "UnixTime", Type: smgutils.LtEq, Value: value.Unix()})
+	return p.b
+}
+
+// LessThan add query operand.
+func (p *SampleSearchUnixTimePropertyInfo) LessThan(value time.Time) *SampleSearchBuilder {
+	p.b.currentOp.Children = append(p.b.currentOp.Children, &smgutils.Op{FieldName: p.Name + "UnixTime", Type: smgutils.Lt, Value: value.Unix()})
+	return p.b
+}
+
+// Equal add query operand.
+func (p *SampleSearchUnixTimePropertyInfo) Equal(value time.Time) *SampleSearchBuilder {
+	p.b.currentOp.Children = append(p.b.currentOp.Children, &smgutils.Op{FieldName: p.Name + "UnixTime", Type: smgutils.Eq, Value: value.Unix()})
+	return p.b
+}
+
+// Asc add query operand.
+func (p *SampleSearchUnixTimePropertyInfo) Asc() *SampleSearchBuilder {
+	if p.b.opts == nil {
+		p.b.opts = &search.SearchOptions{}
+	}
+	if p.b.opts.Sort == nil {
+		p.b.opts.Sort = &search.SortOptions{}
+	}
+	p.b.opts.Sort.Expressions = append(p.b.opts.Sort.Expressions, search.SortExpression{
+		Expr:    p.Name + "UnixTime",
+		Reverse: true,
+	})
+
+	return p.b
+}
+
+// Desc add query operand.
+func (p *SampleSearchUnixTimePropertyInfo) Desc() *SampleSearchBuilder {
+	if p.b.opts == nil {
+		p.b.opts = &search.SearchOptions{}
+	}
+	if p.b.opts.Sort == nil {
+		p.b.opts.Sort = &search.SortOptions{}
+	}
+	p.b.opts.Sort.Expressions = append(p.b.opts.Sort.Expressions, search.SortExpression{
+		Expr:    p.Name + "UnixTime",
+		Reverse: false,
+	})
+
+	return p.b
+}

--- a/misc/fixture/c/model_search.go
+++ b/misc/fixture/c/model_search.go
@@ -498,36 +498,98 @@ type SampleSearchUnixTimePropertyInfo struct {
 
 // GreaterThanOrEqual add query operand.
 func (p *SampleSearchUnixTimePropertyInfo) GreaterThanOrEqual(value time.Time) *SampleSearchBuilder {
-	p.b.currentOp.Children = append(p.b.currentOp.Children, &smgutils.Op{FieldName: p.Name + "UnixTime", Type: smgutils.GtEq, Value: value.Unix()})
+	p.b.currentOp.Children = append(p.b.currentOp.Children, &smgutils.Op{FieldName: p.Name, Type: smgutils.GtEq, Value: value.UTC()})
 	return p.b
 }
 
 // GreaterThan add query operand.
 func (p *SampleSearchUnixTimePropertyInfo) GreaterThan(value time.Time) *SampleSearchBuilder {
-	p.b.currentOp.Children = append(p.b.currentOp.Children, &smgutils.Op{FieldName: p.Name + "UnixTime", Type: smgutils.Gt, Value: value.Unix()})
+	p.b.currentOp.Children = append(p.b.currentOp.Children, &smgutils.Op{FieldName: p.Name, Type: smgutils.Gt, Value: value.UTC()})
 	return p.b
 }
 
 // LessThanOrEqual add query operand.
 func (p *SampleSearchUnixTimePropertyInfo) LessThanOrEqual(value time.Time) *SampleSearchBuilder {
-	p.b.currentOp.Children = append(p.b.currentOp.Children, &smgutils.Op{FieldName: p.Name + "UnixTime", Type: smgutils.LtEq, Value: value.Unix()})
+	p.b.currentOp.Children = append(p.b.currentOp.Children, &smgutils.Op{FieldName: p.Name, Type: smgutils.LtEq, Value: value.UTC()})
 	return p.b
 }
 
 // LessThan add query operand.
 func (p *SampleSearchUnixTimePropertyInfo) LessThan(value time.Time) *SampleSearchBuilder {
-	p.b.currentOp.Children = append(p.b.currentOp.Children, &smgutils.Op{FieldName: p.Name + "UnixTime", Type: smgutils.Lt, Value: value.Unix()})
+	p.b.currentOp.Children = append(p.b.currentOp.Children, &smgutils.Op{FieldName: p.Name, Type: smgutils.Lt, Value: value.UTC()})
 	return p.b
 }
 
 // Equal add query operand.
 func (p *SampleSearchUnixTimePropertyInfo) Equal(value time.Time) *SampleSearchBuilder {
-	p.b.currentOp.Children = append(p.b.currentOp.Children, &smgutils.Op{FieldName: p.Name + "UnixTime", Type: smgutils.Eq, Value: value.Unix()})
+	p.b.currentOp.Children = append(p.b.currentOp.Children, &smgutils.Op{FieldName: p.Name, Type: smgutils.Eq, Value: value.UTC()})
 	return p.b
 }
 
 // Asc add query operand.
 func (p *SampleSearchUnixTimePropertyInfo) Asc() *SampleSearchBuilder {
+	if p.b.opts == nil {
+		p.b.opts = &search.SearchOptions{}
+	}
+	if p.b.opts.Sort == nil {
+		p.b.opts.Sort = &search.SortOptions{}
+	}
+	p.b.opts.Sort.Expressions = append(p.b.opts.Sort.Expressions, search.SortExpression{
+		Expr:    p.Name,
+		Reverse: true,
+	})
+
+	return p.b
+}
+
+// Desc add query operand.
+func (p *SampleSearchUnixTimePropertyInfo) Desc() *SampleSearchBuilder {
+	if p.b.opts == nil {
+		p.b.opts = &search.SearchOptions{}
+	}
+	if p.b.opts.Sort == nil {
+		p.b.opts.Sort = &search.SortOptions{}
+	}
+	p.b.opts.Sort.Expressions = append(p.b.opts.Sort.Expressions, search.SortExpression{
+		Expr:    p.Name,
+		Reverse: false,
+	})
+
+	return p.b
+}
+
+// UnixTimeGreaterThanOrEqual add query operand.
+func (p *SampleSearchUnixTimePropertyInfo) UnixTimeGreaterThanOrEqual(value time.Time) *SampleSearchBuilder {
+	p.b.currentOp.Children = append(p.b.currentOp.Children, &smgutils.Op{FieldName: p.Name + "UnixTime", Type: smgutils.GtEq, Value: smgutils.Unix(value)})
+	return p.b
+}
+
+// UnixTimeGreaterThan add query operand.
+func (p *SampleSearchUnixTimePropertyInfo) UnixTimeGreaterThan(value time.Time) *SampleSearchBuilder {
+	p.b.currentOp.Children = append(p.b.currentOp.Children, &smgutils.Op{FieldName: p.Name + "UnixTime", Type: smgutils.Gt, Value: smgutils.Unix(value)})
+	return p.b
+}
+
+// UnixTimeLessThanOrEqual add query operand.
+func (p *SampleSearchUnixTimePropertyInfo) UnixTimeLessThanOrEqual(value time.Time) *SampleSearchBuilder {
+	p.b.currentOp.Children = append(p.b.currentOp.Children, &smgutils.Op{FieldName: p.Name + "UnixTime", Type: smgutils.LtEq, Value: smgutils.Unix(value)})
+	return p.b
+}
+
+// UnixTimeLessThan add query operand.
+func (p *SampleSearchUnixTimePropertyInfo) UnixTimeLessThan(value time.Time) *SampleSearchBuilder {
+	p.b.currentOp.Children = append(p.b.currentOp.Children, &smgutils.Op{FieldName: p.Name + "UnixTime", Type: smgutils.Lt, Value: smgutils.Unix(value)})
+	return p.b
+}
+
+// UnixTimeEqual add query operand.
+func (p *SampleSearchUnixTimePropertyInfo) UnixTimeEqual(value time.Time) *SampleSearchBuilder {
+	p.b.currentOp.Children = append(p.b.currentOp.Children, &smgutils.Op{FieldName: p.Name + "UnixTime", Type: smgutils.Eq, Value: smgutils.Unix(value)})
+	return p.b
+}
+
+// UnixTimeAsc add query operand.
+func (p *SampleSearchUnixTimePropertyInfo) UnixTimeAsc() *SampleSearchBuilder {
 	if p.b.opts == nil {
 		p.b.opts = &search.SearchOptions{}
 	}
@@ -542,8 +604,8 @@ func (p *SampleSearchUnixTimePropertyInfo) Asc() *SampleSearchBuilder {
 	return p.b
 }
 
-// Desc add query operand.
-func (p *SampleSearchUnixTimePropertyInfo) Desc() *SampleSearchBuilder {
+// UnixTimeDesc add query operand.
+func (p *SampleSearchUnixTimePropertyInfo) UnixTimeDesc() *SampleSearchBuilder {
 	if p.b.opts == nil {
 		p.b.opts = &search.SearchOptions{}
 	}

--- a/misc/fixture/c/model_search.go
+++ b/misc/fixture/c/model_search.go
@@ -489,3 +489,71 @@ func (p *SampleSearchTimePropertyInfo) Desc() *SampleSearchBuilder {
 
 	return p.b
 }
+
+// SampleSearchUnixTimePropertyInfo hold property info.
+type SampleSearchUnixTimePropertyInfo struct {
+	Name string
+	b    *SampleSearchBuilder
+}
+
+// GreaterThanOrEqual add query operand.
+func (p *SampleSearchUnixTimePropertyInfo) GreaterThanOrEqual(value time.Time) *SampleSearchBuilder {
+	p.b.currentOp.Children = append(p.b.currentOp.Children, &smgutils.Op{FieldName: p.Name + "UnixTime", Type: smgutils.GtEq, Value: value.Unix()})
+	return p.b
+}
+
+// GreaterThan add query operand.
+func (p *SampleSearchUnixTimePropertyInfo) GreaterThan(value time.Time) *SampleSearchBuilder {
+	p.b.currentOp.Children = append(p.b.currentOp.Children, &smgutils.Op{FieldName: p.Name + "UnixTime", Type: smgutils.Gt, Value: value.Unix()})
+	return p.b
+}
+
+// LessThanOrEqual add query operand.
+func (p *SampleSearchUnixTimePropertyInfo) LessThanOrEqual(value time.Time) *SampleSearchBuilder {
+	p.b.currentOp.Children = append(p.b.currentOp.Children, &smgutils.Op{FieldName: p.Name + "UnixTime", Type: smgutils.LtEq, Value: value.Unix()})
+	return p.b
+}
+
+// LessThan add query operand.
+func (p *SampleSearchUnixTimePropertyInfo) LessThan(value time.Time) *SampleSearchBuilder {
+	p.b.currentOp.Children = append(p.b.currentOp.Children, &smgutils.Op{FieldName: p.Name + "UnixTime", Type: smgutils.Lt, Value: value.Unix()})
+	return p.b
+}
+
+// Equal add query operand.
+func (p *SampleSearchUnixTimePropertyInfo) Equal(value time.Time) *SampleSearchBuilder {
+	p.b.currentOp.Children = append(p.b.currentOp.Children, &smgutils.Op{FieldName: p.Name + "UnixTime", Type: smgutils.Eq, Value: value.Unix()})
+	return p.b
+}
+
+// Asc add query operand.
+func (p *SampleSearchUnixTimePropertyInfo) Asc() *SampleSearchBuilder {
+	if p.b.opts == nil {
+		p.b.opts = &search.SearchOptions{}
+	}
+	if p.b.opts.Sort == nil {
+		p.b.opts.Sort = &search.SortOptions{}
+	}
+	p.b.opts.Sort.Expressions = append(p.b.opts.Sort.Expressions, search.SortExpression{
+		Expr:    p.Name + "UnixTime",
+		Reverse: true,
+	})
+
+	return p.b
+}
+
+// Desc add query operand.
+func (p *SampleSearchUnixTimePropertyInfo) Desc() *SampleSearchBuilder {
+	if p.b.opts == nil {
+		p.b.opts = &search.SearchOptions{}
+	}
+	if p.b.opts.Sort == nil {
+		p.b.opts.Sort = &search.SortOptions{}
+	}
+	p.b.opts.Sort.Expressions = append(p.b.opts.Sort.Expressions, search.SortExpression{
+		Expr:    p.Name + "UnixTime",
+		Reverse: false,
+	})
+
+	return p.b
+}

--- a/misc/fixture/d/model_search.go
+++ b/misc/fixture/d/model_search.go
@@ -479,3 +479,71 @@ func (p *SampleSearchTimePropertyInfo) Desc() *SampleSearchBuilder {
 
 	return p.b
 }
+
+// SampleSearchUnixTimePropertyInfo hold property info.
+type SampleSearchUnixTimePropertyInfo struct {
+	Name string
+	b    *SampleSearchBuilder
+}
+
+// GreaterThanOrEqual add query operand.
+func (p *SampleSearchUnixTimePropertyInfo) GreaterThanOrEqual(value time.Time) *SampleSearchBuilder {
+	p.b.currentOp.Children = append(p.b.currentOp.Children, &smgutils.Op{FieldName: p.Name + "UnixTime", Type: smgutils.GtEq, Value: value.Unix()})
+	return p.b
+}
+
+// GreaterThan add query operand.
+func (p *SampleSearchUnixTimePropertyInfo) GreaterThan(value time.Time) *SampleSearchBuilder {
+	p.b.currentOp.Children = append(p.b.currentOp.Children, &smgutils.Op{FieldName: p.Name + "UnixTime", Type: smgutils.Gt, Value: value.Unix()})
+	return p.b
+}
+
+// LessThanOrEqual add query operand.
+func (p *SampleSearchUnixTimePropertyInfo) LessThanOrEqual(value time.Time) *SampleSearchBuilder {
+	p.b.currentOp.Children = append(p.b.currentOp.Children, &smgutils.Op{FieldName: p.Name + "UnixTime", Type: smgutils.LtEq, Value: value.Unix()})
+	return p.b
+}
+
+// LessThan add query operand.
+func (p *SampleSearchUnixTimePropertyInfo) LessThan(value time.Time) *SampleSearchBuilder {
+	p.b.currentOp.Children = append(p.b.currentOp.Children, &smgutils.Op{FieldName: p.Name + "UnixTime", Type: smgutils.Lt, Value: value.Unix()})
+	return p.b
+}
+
+// Equal add query operand.
+func (p *SampleSearchUnixTimePropertyInfo) Equal(value time.Time) *SampleSearchBuilder {
+	p.b.currentOp.Children = append(p.b.currentOp.Children, &smgutils.Op{FieldName: p.Name + "UnixTime", Type: smgutils.Eq, Value: value.Unix()})
+	return p.b
+}
+
+// Asc add query operand.
+func (p *SampleSearchUnixTimePropertyInfo) Asc() *SampleSearchBuilder {
+	if p.b.opts == nil {
+		p.b.opts = &search.SearchOptions{}
+	}
+	if p.b.opts.Sort == nil {
+		p.b.opts.Sort = &search.SortOptions{}
+	}
+	p.b.opts.Sort.Expressions = append(p.b.opts.Sort.Expressions, search.SortExpression{
+		Expr:    p.Name + "UnixTime",
+		Reverse: true,
+	})
+
+	return p.b
+}
+
+// Desc add query operand.
+func (p *SampleSearchUnixTimePropertyInfo) Desc() *SampleSearchBuilder {
+	if p.b.opts == nil {
+		p.b.opts = &search.SearchOptions{}
+	}
+	if p.b.opts.Sort == nil {
+		p.b.opts.Sort = &search.SortOptions{}
+	}
+	p.b.opts.Sort.Expressions = append(p.b.opts.Sort.Expressions, search.SortExpression{
+		Expr:    p.Name + "UnixTime",
+		Reverse: false,
+	})
+
+	return p.b
+}

--- a/misc/fixture/d/model_search.go
+++ b/misc/fixture/d/model_search.go
@@ -488,36 +488,98 @@ type SampleSearchUnixTimePropertyInfo struct {
 
 // GreaterThanOrEqual add query operand.
 func (p *SampleSearchUnixTimePropertyInfo) GreaterThanOrEqual(value time.Time) *SampleSearchBuilder {
-	p.b.currentOp.Children = append(p.b.currentOp.Children, &smgutils.Op{FieldName: p.Name + "UnixTime", Type: smgutils.GtEq, Value: value.Unix()})
+	p.b.currentOp.Children = append(p.b.currentOp.Children, &smgutils.Op{FieldName: p.Name, Type: smgutils.GtEq, Value: value.UTC()})
 	return p.b
 }
 
 // GreaterThan add query operand.
 func (p *SampleSearchUnixTimePropertyInfo) GreaterThan(value time.Time) *SampleSearchBuilder {
-	p.b.currentOp.Children = append(p.b.currentOp.Children, &smgutils.Op{FieldName: p.Name + "UnixTime", Type: smgutils.Gt, Value: value.Unix()})
+	p.b.currentOp.Children = append(p.b.currentOp.Children, &smgutils.Op{FieldName: p.Name, Type: smgutils.Gt, Value: value.UTC()})
 	return p.b
 }
 
 // LessThanOrEqual add query operand.
 func (p *SampleSearchUnixTimePropertyInfo) LessThanOrEqual(value time.Time) *SampleSearchBuilder {
-	p.b.currentOp.Children = append(p.b.currentOp.Children, &smgutils.Op{FieldName: p.Name + "UnixTime", Type: smgutils.LtEq, Value: value.Unix()})
+	p.b.currentOp.Children = append(p.b.currentOp.Children, &smgutils.Op{FieldName: p.Name, Type: smgutils.LtEq, Value: value.UTC()})
 	return p.b
 }
 
 // LessThan add query operand.
 func (p *SampleSearchUnixTimePropertyInfo) LessThan(value time.Time) *SampleSearchBuilder {
-	p.b.currentOp.Children = append(p.b.currentOp.Children, &smgutils.Op{FieldName: p.Name + "UnixTime", Type: smgutils.Lt, Value: value.Unix()})
+	p.b.currentOp.Children = append(p.b.currentOp.Children, &smgutils.Op{FieldName: p.Name, Type: smgutils.Lt, Value: value.UTC()})
 	return p.b
 }
 
 // Equal add query operand.
 func (p *SampleSearchUnixTimePropertyInfo) Equal(value time.Time) *SampleSearchBuilder {
-	p.b.currentOp.Children = append(p.b.currentOp.Children, &smgutils.Op{FieldName: p.Name + "UnixTime", Type: smgutils.Eq, Value: value.Unix()})
+	p.b.currentOp.Children = append(p.b.currentOp.Children, &smgutils.Op{FieldName: p.Name, Type: smgutils.Eq, Value: value.UTC()})
 	return p.b
 }
 
 // Asc add query operand.
 func (p *SampleSearchUnixTimePropertyInfo) Asc() *SampleSearchBuilder {
+	if p.b.opts == nil {
+		p.b.opts = &search.SearchOptions{}
+	}
+	if p.b.opts.Sort == nil {
+		p.b.opts.Sort = &search.SortOptions{}
+	}
+	p.b.opts.Sort.Expressions = append(p.b.opts.Sort.Expressions, search.SortExpression{
+		Expr:    p.Name,
+		Reverse: true,
+	})
+
+	return p.b
+}
+
+// Desc add query operand.
+func (p *SampleSearchUnixTimePropertyInfo) Desc() *SampleSearchBuilder {
+	if p.b.opts == nil {
+		p.b.opts = &search.SearchOptions{}
+	}
+	if p.b.opts.Sort == nil {
+		p.b.opts.Sort = &search.SortOptions{}
+	}
+	p.b.opts.Sort.Expressions = append(p.b.opts.Sort.Expressions, search.SortExpression{
+		Expr:    p.Name,
+		Reverse: false,
+	})
+
+	return p.b
+}
+
+// UnixTimeGreaterThanOrEqual add query operand.
+func (p *SampleSearchUnixTimePropertyInfo) UnixTimeGreaterThanOrEqual(value time.Time) *SampleSearchBuilder {
+	p.b.currentOp.Children = append(p.b.currentOp.Children, &smgutils.Op{FieldName: p.Name + "UnixTime", Type: smgutils.GtEq, Value: smgutils.Unix(value)})
+	return p.b
+}
+
+// UnixTimeGreaterThan add query operand.
+func (p *SampleSearchUnixTimePropertyInfo) UnixTimeGreaterThan(value time.Time) *SampleSearchBuilder {
+	p.b.currentOp.Children = append(p.b.currentOp.Children, &smgutils.Op{FieldName: p.Name + "UnixTime", Type: smgutils.Gt, Value: smgutils.Unix(value)})
+	return p.b
+}
+
+// UnixTimeLessThanOrEqual add query operand.
+func (p *SampleSearchUnixTimePropertyInfo) UnixTimeLessThanOrEqual(value time.Time) *SampleSearchBuilder {
+	p.b.currentOp.Children = append(p.b.currentOp.Children, &smgutils.Op{FieldName: p.Name + "UnixTime", Type: smgutils.LtEq, Value: smgutils.Unix(value)})
+	return p.b
+}
+
+// UnixTimeLessThan add query operand.
+func (p *SampleSearchUnixTimePropertyInfo) UnixTimeLessThan(value time.Time) *SampleSearchBuilder {
+	p.b.currentOp.Children = append(p.b.currentOp.Children, &smgutils.Op{FieldName: p.Name + "UnixTime", Type: smgutils.Lt, Value: smgutils.Unix(value)})
+	return p.b
+}
+
+// UnixTimeEqual add query operand.
+func (p *SampleSearchUnixTimePropertyInfo) UnixTimeEqual(value time.Time) *SampleSearchBuilder {
+	p.b.currentOp.Children = append(p.b.currentOp.Children, &smgutils.Op{FieldName: p.Name + "UnixTime", Type: smgutils.Eq, Value: smgutils.Unix(value)})
+	return p.b
+}
+
+// UnixTimeAsc add query operand.
+func (p *SampleSearchUnixTimePropertyInfo) UnixTimeAsc() *SampleSearchBuilder {
 	if p.b.opts == nil {
 		p.b.opts = &search.SearchOptions{}
 	}
@@ -532,8 +594,8 @@ func (p *SampleSearchUnixTimePropertyInfo) Asc() *SampleSearchBuilder {
 	return p.b
 }
 
-// Desc add query operand.
-func (p *SampleSearchUnixTimePropertyInfo) Desc() *SampleSearchBuilder {
+// UnixTimeDesc add query operand.
+func (p *SampleSearchUnixTimePropertyInfo) UnixTimeDesc() *SampleSearchBuilder {
 	if p.b.opts == nil {
 		p.b.opts = &search.SearchOptions{}
 	}

--- a/misc/fixture/e/model.go
+++ b/misc/fixture/e/model.go
@@ -21,7 +21,7 @@ type Inventory struct {
 	AdminNames  []string  `search:",json"`
 	Shops       []*Shop   `search:",json"`
 	CreatedAt   time.Time `datastore:",noindex"`
-	UpdatedAt   time.Time `datastore:",noindex" search:"-"`
+	UpdatedAt   time.Time `datastore:",noindex" search:",unixtime"`
 }
 
 type Shop struct {

--- a/misc/fixture/e/model_search.go
+++ b/misc/fixture/e/model_search.go
@@ -94,15 +94,7 @@ func (src *Inventory) Searchfy() (*InventorySearch, error) {
 	}
 	dest.CreatedAt = src.CreatedAt
 
-	// Number Field is value between -2,147,483,647 and 2,147,483,647.
-	// https://cloud.google.com/appengine/docs/go/search/#Go_Documents_and_fields
-	unixtime := src.UpdatedAt.Unix()
-	if unixtime < -2147483647 {
-		unixtime = -2147483647
-	} else if 2147483647 < unixtime {
-		unixtime = 2147483647
-	}
-	dest.UpdatedAtUnixTime = float64(unixtime)
+	dest.UpdatedAtUnixTime = float64(smgutils.Unix(src.UpdatedAt))
 	dest.UpdatedAt = src.UpdatedAt
 	return dest, nil
 }
@@ -582,36 +574,98 @@ type InventorySearchUnixTimePropertyInfo struct {
 
 // GreaterThanOrEqual add query operand.
 func (p *InventorySearchUnixTimePropertyInfo) GreaterThanOrEqual(value time.Time) *InventorySearchBuilder {
-	p.b.currentOp.Children = append(p.b.currentOp.Children, &smgutils.Op{FieldName: p.Name + "UnixTime", Type: smgutils.GtEq, Value: value.Unix()})
+	p.b.currentOp.Children = append(p.b.currentOp.Children, &smgutils.Op{FieldName: p.Name, Type: smgutils.GtEq, Value: value.UTC()})
 	return p.b
 }
 
 // GreaterThan add query operand.
 func (p *InventorySearchUnixTimePropertyInfo) GreaterThan(value time.Time) *InventorySearchBuilder {
-	p.b.currentOp.Children = append(p.b.currentOp.Children, &smgutils.Op{FieldName: p.Name + "UnixTime", Type: smgutils.Gt, Value: value.Unix()})
+	p.b.currentOp.Children = append(p.b.currentOp.Children, &smgutils.Op{FieldName: p.Name, Type: smgutils.Gt, Value: value.UTC()})
 	return p.b
 }
 
 // LessThanOrEqual add query operand.
 func (p *InventorySearchUnixTimePropertyInfo) LessThanOrEqual(value time.Time) *InventorySearchBuilder {
-	p.b.currentOp.Children = append(p.b.currentOp.Children, &smgutils.Op{FieldName: p.Name + "UnixTime", Type: smgutils.LtEq, Value: value.Unix()})
+	p.b.currentOp.Children = append(p.b.currentOp.Children, &smgutils.Op{FieldName: p.Name, Type: smgutils.LtEq, Value: value.UTC()})
 	return p.b
 }
 
 // LessThan add query operand.
 func (p *InventorySearchUnixTimePropertyInfo) LessThan(value time.Time) *InventorySearchBuilder {
-	p.b.currentOp.Children = append(p.b.currentOp.Children, &smgutils.Op{FieldName: p.Name + "UnixTime", Type: smgutils.Lt, Value: value.Unix()})
+	p.b.currentOp.Children = append(p.b.currentOp.Children, &smgutils.Op{FieldName: p.Name, Type: smgutils.Lt, Value: value.UTC()})
 	return p.b
 }
 
 // Equal add query operand.
 func (p *InventorySearchUnixTimePropertyInfo) Equal(value time.Time) *InventorySearchBuilder {
-	p.b.currentOp.Children = append(p.b.currentOp.Children, &smgutils.Op{FieldName: p.Name + "UnixTime", Type: smgutils.Eq, Value: value.Unix()})
+	p.b.currentOp.Children = append(p.b.currentOp.Children, &smgutils.Op{FieldName: p.Name, Type: smgutils.Eq, Value: value.UTC()})
 	return p.b
 }
 
 // Asc add query operand.
 func (p *InventorySearchUnixTimePropertyInfo) Asc() *InventorySearchBuilder {
+	if p.b.opts == nil {
+		p.b.opts = &search.SearchOptions{}
+	}
+	if p.b.opts.Sort == nil {
+		p.b.opts.Sort = &search.SortOptions{}
+	}
+	p.b.opts.Sort.Expressions = append(p.b.opts.Sort.Expressions, search.SortExpression{
+		Expr:    p.Name,
+		Reverse: true,
+	})
+
+	return p.b
+}
+
+// Desc add query operand.
+func (p *InventorySearchUnixTimePropertyInfo) Desc() *InventorySearchBuilder {
+	if p.b.opts == nil {
+		p.b.opts = &search.SearchOptions{}
+	}
+	if p.b.opts.Sort == nil {
+		p.b.opts.Sort = &search.SortOptions{}
+	}
+	p.b.opts.Sort.Expressions = append(p.b.opts.Sort.Expressions, search.SortExpression{
+		Expr:    p.Name,
+		Reverse: false,
+	})
+
+	return p.b
+}
+
+// UnixTimeGreaterThanOrEqual add query operand.
+func (p *InventorySearchUnixTimePropertyInfo) UnixTimeGreaterThanOrEqual(value time.Time) *InventorySearchBuilder {
+	p.b.currentOp.Children = append(p.b.currentOp.Children, &smgutils.Op{FieldName: p.Name + "UnixTime", Type: smgutils.GtEq, Value: smgutils.Unix(value)})
+	return p.b
+}
+
+// UnixTimeGreaterThan add query operand.
+func (p *InventorySearchUnixTimePropertyInfo) UnixTimeGreaterThan(value time.Time) *InventorySearchBuilder {
+	p.b.currentOp.Children = append(p.b.currentOp.Children, &smgutils.Op{FieldName: p.Name + "UnixTime", Type: smgutils.Gt, Value: smgutils.Unix(value)})
+	return p.b
+}
+
+// UnixTimeLessThanOrEqual add query operand.
+func (p *InventorySearchUnixTimePropertyInfo) UnixTimeLessThanOrEqual(value time.Time) *InventorySearchBuilder {
+	p.b.currentOp.Children = append(p.b.currentOp.Children, &smgutils.Op{FieldName: p.Name + "UnixTime", Type: smgutils.LtEq, Value: smgutils.Unix(value)})
+	return p.b
+}
+
+// UnixTimeLessThan add query operand.
+func (p *InventorySearchUnixTimePropertyInfo) UnixTimeLessThan(value time.Time) *InventorySearchBuilder {
+	p.b.currentOp.Children = append(p.b.currentOp.Children, &smgutils.Op{FieldName: p.Name + "UnixTime", Type: smgutils.Lt, Value: smgutils.Unix(value)})
+	return p.b
+}
+
+// UnixTimeEqual add query operand.
+func (p *InventorySearchUnixTimePropertyInfo) UnixTimeEqual(value time.Time) *InventorySearchBuilder {
+	p.b.currentOp.Children = append(p.b.currentOp.Children, &smgutils.Op{FieldName: p.Name + "UnixTime", Type: smgutils.Eq, Value: smgutils.Unix(value)})
+	return p.b
+}
+
+// UnixTimeAsc add query operand.
+func (p *InventorySearchUnixTimePropertyInfo) UnixTimeAsc() *InventorySearchBuilder {
 	if p.b.opts == nil {
 		p.b.opts = &search.SearchOptions{}
 	}
@@ -626,8 +680,8 @@ func (p *InventorySearchUnixTimePropertyInfo) Asc() *InventorySearchBuilder {
 	return p.b
 }
 
-// Desc add query operand.
-func (p *InventorySearchUnixTimePropertyInfo) Desc() *InventorySearchBuilder {
+// UnixTimeDesc add query operand.
+func (p *InventorySearchUnixTimePropertyInfo) UnixTimeDesc() *InventorySearchBuilder {
 	if p.b.opts == nil {
 		p.b.opts = &search.SearchOptions{}
 	}

--- a/misc/fixture/e/model_search.go
+++ b/misc/fixture/e/model_search.go
@@ -29,6 +29,8 @@ type InventorySearch struct {
 	AdminNames         string
 	Shops              string
 	CreatedAt          time.Time
+	UpdatedAt          time.Time
+	UpdatedAtUnixTime  float64
 }
 
 // Load by search.LoadStruct.
@@ -91,6 +93,15 @@ func (src *Inventory) Searchfy() (*InventorySearch, error) {
 		dest.Shops = str
 	}
 	dest.CreatedAt = src.CreatedAt
+
+	// Number Field is value between -2,147,483,647 and 2,147,483,647.
+	// but, value of zero time is -62,135,596,800.
+	if src.UpdatedAt.IsZero() {
+		dest.UpdatedAtUnixTime = float64(-1)
+	} else {
+		dest.UpdatedAtUnixTime = float64(src.UpdatedAt.Unix())
+	}
+	dest.UpdatedAt = src.UpdatedAt
 	return dest, nil
 }
 
@@ -109,6 +120,7 @@ func NewInventorySearch() *InventorySearchBuilder {
 	b.AdminNames = &InventorySearchStringPropertyInfo{"AdminNames", b}
 	b.Shops = &InventorySearchStringPropertyInfo{"Shops", b}
 	b.CreatedAt = &InventorySearchTimePropertyInfo{"CreatedAt", b}
+	b.UpdatedAt = &InventorySearchUnixTimePropertyInfo{"UpdatedAt", b}
 
 	return b
 }
@@ -128,6 +140,7 @@ type InventorySearchBuilder struct {
 	AdminNames  *InventorySearchStringPropertyInfo
 	Shops       *InventorySearchStringPropertyInfo
 	CreatedAt   *InventorySearchTimePropertyInfo
+	UpdatedAt   *InventorySearchUnixTimePropertyInfo
 }
 
 // And append new operant to query.
@@ -553,6 +566,74 @@ func (p *InventorySearchTimePropertyInfo) Desc() *InventorySearchBuilder {
 	}
 	p.b.opts.Sort.Expressions = append(p.b.opts.Sort.Expressions, search.SortExpression{
 		Expr:    p.Name,
+		Reverse: false,
+	})
+
+	return p.b
+}
+
+// InventorySearchUnixTimePropertyInfo hold property info.
+type InventorySearchUnixTimePropertyInfo struct {
+	Name string
+	b    *InventorySearchBuilder
+}
+
+// GreaterThanOrEqual add query operand.
+func (p *InventorySearchUnixTimePropertyInfo) GreaterThanOrEqual(value time.Time) *InventorySearchBuilder {
+	p.b.currentOp.Children = append(p.b.currentOp.Children, &smgutils.Op{FieldName: p.Name + "UnixTime", Type: smgutils.GtEq, Value: value.Unix()})
+	return p.b
+}
+
+// GreaterThan add query operand.
+func (p *InventorySearchUnixTimePropertyInfo) GreaterThan(value time.Time) *InventorySearchBuilder {
+	p.b.currentOp.Children = append(p.b.currentOp.Children, &smgutils.Op{FieldName: p.Name + "UnixTime", Type: smgutils.Gt, Value: value.Unix()})
+	return p.b
+}
+
+// LessThanOrEqual add query operand.
+func (p *InventorySearchUnixTimePropertyInfo) LessThanOrEqual(value time.Time) *InventorySearchBuilder {
+	p.b.currentOp.Children = append(p.b.currentOp.Children, &smgutils.Op{FieldName: p.Name + "UnixTime", Type: smgutils.LtEq, Value: value.Unix()})
+	return p.b
+}
+
+// LessThan add query operand.
+func (p *InventorySearchUnixTimePropertyInfo) LessThan(value time.Time) *InventorySearchBuilder {
+	p.b.currentOp.Children = append(p.b.currentOp.Children, &smgutils.Op{FieldName: p.Name + "UnixTime", Type: smgutils.Lt, Value: value.Unix()})
+	return p.b
+}
+
+// Equal add query operand.
+func (p *InventorySearchUnixTimePropertyInfo) Equal(value time.Time) *InventorySearchBuilder {
+	p.b.currentOp.Children = append(p.b.currentOp.Children, &smgutils.Op{FieldName: p.Name + "UnixTime", Type: smgutils.Eq, Value: value.Unix()})
+	return p.b
+}
+
+// Asc add query operand.
+func (p *InventorySearchUnixTimePropertyInfo) Asc() *InventorySearchBuilder {
+	if p.b.opts == nil {
+		p.b.opts = &search.SearchOptions{}
+	}
+	if p.b.opts.Sort == nil {
+		p.b.opts.Sort = &search.SortOptions{}
+	}
+	p.b.opts.Sort.Expressions = append(p.b.opts.Sort.Expressions, search.SortExpression{
+		Expr:    p.Name + "UnixTime",
+		Reverse: true,
+	})
+
+	return p.b
+}
+
+// Desc add query operand.
+func (p *InventorySearchUnixTimePropertyInfo) Desc() *InventorySearchBuilder {
+	if p.b.opts == nil {
+		p.b.opts = &search.SearchOptions{}
+	}
+	if p.b.opts.Sort == nil {
+		p.b.opts.Sort = &search.SortOptions{}
+	}
+	p.b.opts.Sort.Expressions = append(p.b.opts.Sort.Expressions, search.SortExpression{
+		Expr:    p.Name + "UnixTime",
 		Reverse: false,
 	})
 

--- a/misc/fixture/e/model_search.go
+++ b/misc/fixture/e/model_search.go
@@ -95,12 +95,14 @@ func (src *Inventory) Searchfy() (*InventorySearch, error) {
 	dest.CreatedAt = src.CreatedAt
 
 	// Number Field is value between -2,147,483,647 and 2,147,483,647.
-	// but, value of zero time is -62,135,596,800.
-	if src.UpdatedAt.IsZero() {
-		dest.UpdatedAtUnixTime = float64(-1)
-	} else {
-		dest.UpdatedAtUnixTime = float64(src.UpdatedAt.Unix())
+	// https://cloud.google.com/appengine/docs/go/search/#Go_Documents_and_fields
+	unixtime := src.UpdatedAt.Unix()
+	if unixtime < -2147483647 {
+		unixtime = -2147483647
+	} else if 2147483647 < unixtime {
+		unixtime = 2147483647
 	}
+	dest.UpdatedAtUnixTime = float64(unixtime)
 	dest.UpdatedAt = src.UpdatedAt
 	return dest, nil
 }

--- a/smgutils/utils.go
+++ b/smgutils/utils.go
@@ -240,3 +240,16 @@ func Sanitize(value string) string {
 	value = strings.Replace(value, `"`, `\"`, -1)
 	return value
 }
+
+// Unix returns unix time.
+// Number Field is value between -2,147,483,647 and 2,147,483,647.
+// https://cloud.google.com/appengine/docs/go/search/#Go_Documents_and_fields
+func Unix(t time.Time) int64 {
+	unixtime := t.Unix()
+	if unixtime < -2147483647 {
+		unixtime = -2147483647
+	} else if 2147483647 < unixtime {
+		unixtime = 2147483647
+	}
+	return unixtime
+}

--- a/smgutils/utils_test.go
+++ b/smgutils/utils_test.go
@@ -163,3 +163,32 @@ func TestSanitize(t *testing.T) {
 		t.Errorf("unexpected: %s", s)
 	}
 }
+
+func TestUnix(t *testing.T) {
+	utc, err := time.LoadLocation("UTC")
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+	unixtime := Unix(time.Date(1970, 1, 1, 0, 0, 0, 0, utc))
+	if unixtime != 0 {
+		t.Errorf("unexpected: %d", unixtime)
+	}
+}
+
+func TestUnixMax(t *testing.T) {
+	utc, err := time.LoadLocation("UTC")
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+	unixtime := Unix(time.Date(2050, 1, 1, 0, 0, 0, 0, utc))
+	if unixtime != 2147483647 {
+		t.Errorf("unexpected: %d", unixtime)
+	}
+}
+
+func TestUnixMin(t *testing.T) {
+	unixtime := Unix(time.Time{})
+	if unixtime != -2147483647 {
+		t.Errorf("unexpected: %d", unixtime)
+	}
+}


### PR DESCRIPTION
Hi @vvakame 
Default Search API does not support searches in time.
This patch is support search `time.Time` by unix time.

How to use

``` go
type Sample struct {
    createdAt time.Time `search:",unixtime"`
}
```
